### PR TITLE
Do not search with triple backticks

### DIFF
--- a/ffbot3/Program.cs
+++ b/ffbot3/Program.cs
@@ -150,11 +150,11 @@ namespace FFBot2
 
         private async static Task<Discord.Embed> GetResponse(string message, string user)
         {
-            var networkRegex = new Regex("`([^`]+)`|!l\\(([^)]+)\\)|link\\(([^)]+)\\)", RegexOptions.IgnoreCase);
-            var ffnRegex = new Regex("linkffn\\(([^)]+)\\)", RegexOptions.IgnoreCase);
-            var ao3Regex = new Regex("linkao3\\(([^)]+)\\)", RegexOptions.IgnoreCase);
+            var networkRegex = new Regex(@"`([^`]+)`|!l\(([^)]+)\)|link\(([^)]+)\)", RegexOptions.IgnoreCase);
+            var ffnRegex = new Regex(@"linkffn\(([^)]+)\)", RegexOptions.IgnoreCase);
+            var ao3Regex = new Regex(@"linkao3\(([^)]+)\)", RegexOptions.IgnoreCase);
 
-            var linkRegex = new Regex("https?:\\/\\/[^\\s]+", RegexOptions.IgnoreCase);
+            var linkRegex = new Regex(@"https?:\/\/[^\s]+", RegexOptions.IgnoreCase);
 
             // First, let's look at directly linked stories:
             var ficLink = FicLink.From(message);

--- a/ffbot3/Program.cs
+++ b/ffbot3/Program.cs
@@ -150,7 +150,7 @@ namespace FFBot2
 
         private async static Task<Discord.Embed> GetResponse(string message, string user)
         {
-            var networkRegex = new Regex(@"`([^`]+)`|!l\(([^)]+)\)|link\(([^)]+)\)", RegexOptions.IgnoreCase);
+            var networkRegex = new Regex(@"^`([^`]+)`|[^`]+`([^`]+)`|!l\(([^)]+)\)|link\(([^)]+)\)", RegexOptions.IgnoreCase);
             var ffnRegex = new Regex(@"linkffn\(([^)]+)\)", RegexOptions.IgnoreCase);
             var ao3Regex = new Regex(@"linkao3\(([^)]+)\)", RegexOptions.IgnoreCase);
 


### PR DESCRIPTION
The previous regex part
\`([^\`]+)\`
matches both \`quote\` and \`\`\`quote\`\`\`.

However, it is useful to make a submit a chat message with a quote that will not be searched for. And it is hard to see why anybody would use a pair of three ticks to get a response from the bot when they can make do with a pair of just one.

The new regex part
^\`([^\`]+)\`
will match \`quote\` at the beginning of a message.

The new regex part
[^\`]+\`([^\`]+)\`
will match \`quote\` within a message only if it is not preceded by a backtick, so it won't match \`\`\`quote\`\`\`